### PR TITLE
fix(ch05): add required mysql environment variable

### DIFF
--- a/ch05/manifests/pricelist-db.yaml
+++ b/ch05/manifests/pricelist-db.yaml
@@ -30,6 +30,8 @@ spec:
           value: pricelist
         - name: MYSQL_USER
           value: pricelist
+        - name: MYSQL_RANDOM_ROOT_PASSWORD
+          value: yes
         volumeMounts:
         - mountPath: /var/lib/mysql/data
           name: mysql-db

--- a/ch07/appset-bgd.yaml
+++ b/ch07/appset-bgd.yaml
@@ -11,15 +11,17 @@ spec:
         gitRepo: https://github.com/christianh814/gitops-examples
         appPath: applicationsets/list-generator/v0.2/k8s/overlays
         appBranch: main
+        server: https://192.168.122.80:6443
       - overlay: green
         gitRepo: https://gitlab.com/christianh814/test-applicationsets.git
         appPath: list-generator/k8s/overlays
         appBranch: main
+        server: https://kubernetes.default.svc
   template:
     metadata:
       name: 'bgd-{{overlay}}'
     spec:
-      project: default
+      project: learning
       syncPolicy:
         automated:
           prune: true
@@ -35,5 +37,5 @@ spec:
         targetRevision: '{{appBranch}}'
         path: '{{appPath}}/{{overlay}}'
       destination:
-        server: https://kubernetes.default.svc
+        server: '{{server}}'
         namespace: 'bgd-{{overlay}}'


### PR DESCRIPTION
Mysql does not come up without one of the following environment variables:
- MYSQL_ROOT_PASSWORD
- MYSQL_ALLOW_EMPTY_PASSWORD
- MYSQL_RANDOM_ROOT_PASSWORD

For testing and studying purposes, a random password generated by mysql itself should be fine