### PR TITLE
fix(ch05): add required mysql environment variable on Up and Running book example

### DIFF
--- a/ch05/manifests/pricelist-db.yaml
+++ b/ch05/manifests/pricelist-db.yaml
@@ -30,6 +30,8 @@ spec:
           value: pricelist
         - name: MYSQL_USER
           value: pricelist
+        - name: MYSQL_RANDOM_ROOT_PASSWORD
+          value: yes
         volumeMounts:
         - mountPath: /var/lib/mysql/data
           name: mysql-db


### PR DESCRIPTION
Mysql Application on Up and Running book does not work doe to a missing environment variable.

It should be one of the following environment variables:
- MYSQL_ROOT_PASSWORD
- MYSQL_ALLOW_EMPTY_PASSWORD
- MYSQL_RANDOM_ROOT_PASSWORD

For testing and studying purposes, a random password generated by mysql itself should be fine.