### PR TITLE
update mariadb chart version

### DIFF
--- a/ch08/argocd/applications/golist-db.yaml
+++ b/ch08/argocd/applications/golist-db.yaml
@@ -17,7 +17,7 @@ spec:
           value: "golist"
     chart: mariadb
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 11.1.0
+    targetRevision: 18.1.0
   destination:
     namespace: golist
     server: 'https://kubernetes.default.svc'

--- a/ch10/apps/golist-db/Chart.yaml
+++ b/ch10/apps/golist-db/Chart.yaml
@@ -5,5 +5,5 @@ version: 1.0.0
 appVersion: "1.0.0"
 dependencies:
 - name: mariadb
-  version: 11.1.0
+  version: 18.1.0
   repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
update mariadb chart version . 

the version on file 11.1.0 is causing this error: 


Back-off pulling image "docker.io/bitnami/mariadb:10.6.8-debian-11-r9": ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/bitnami/mariadb:10.6.8-debian-11-r9": failed to resolve reference "docker.io/bitnami/mariadb:10.6.8-debian-11-r9": docker.io/bitnami/mariadb:10.6.8-debian-11-r9: not found