### PR TITLE
update: update the image for the tekton task git-clone

### DIFF
--- a/ch12/tekton/pipelines/git-clone-task.yaml
+++ b/ch12/tekton/pipelines/git-clone-task.yaml
@@ -102,7 +102,7 @@ spec:
     - name: gitInitImage
       description: The image providing the git-init binary that this Task runs.
       type: string
-      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.40.2"
+      default: "ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/git-init:v0.40.2"
     - name: userHome
       description: |
         Absolute path to the user's home directory.


### PR DESCRIPTION
based on https://tekton.dev/blog/2025/04/03/migration-to-github-container-registry/ , the image reference in the task git-clone-task.yaml . needs to be updated. 